### PR TITLE
attoparsec 0.10 support

### DIFF
--- a/asn1-data.cabal
+++ b/asn1-data.cabal
@@ -1,5 +1,5 @@
 Name:                asn1-data
-Version:             0.6.0
+Version:             0.6.0.1
 Description:
     ASN1 data reader and writer in raw form with supports for high level forms of ASN1 (BER, CER and DER).
     .
@@ -27,8 +27,8 @@ Library
                    , bytestring
                    , text >= 0.11
                    , enumerator >= 0.4.5 && < 0.5
-                   , attoparsec >= 0.8 && < 0.10
-                   , attoparsec-enumerator >= 0.2 && < 0.3
+                   , attoparsec >= 0.8 && < 0.11
+                   , attoparsec-enumerator >= 0.2 && < 0.4
                    , mtl
   Exposed-modules:   Data.ASN1.BER
                      Data.ASN1.CER


### PR DESCRIPTION
No code changes are required for attoparsec 0.10 support, just bumping bounds in the cabal file.
