### PR TITLE
support decoding of enumerated values.

### DIFF
--- a/types/Data/ASN1/Types.hs
+++ b/types/Data/ASN1/Types.hs
@@ -48,7 +48,7 @@ data ASN1 =
     | Null
     | OID  OID
     | Real Double
-    | Enumerated Int
+    | Enumerated Integer
     | ASN1String ASN1CharacterString
     | ASN1Time ASN1TimeType UTCTime (Maybe TimeZone)
     | Other ASN1Class ASN1Tag ByteString


### PR DESCRIPTION
I'd like to decode ASN.1 ByteStrings that contain enumerated values. According to X.690 section 8.4, an integer and enumerated value should have the same representation, so I shared the decoding logic between those two types.

The `Enumerated` constructor now holds an `Integer` rather than an `Int`.
