### PR TITLE
Add conduit interface to ASN1 decoder

### DIFF
--- a/encoding/Data/ASN1/Encoding.hs
+++ b/encoding/Data/ASN1/Encoding.hs
@@ -5,11 +5,14 @@
 -- Stability   : experimental
 -- Portability : unknown
 --
+{-# LANGUAGE RankNTypes #-}
 module Data.ASN1.Encoding
     (
     -- * generic class for decoding and encoding stream
       ASN1Decoding(..)
     , ASN1DecodingRepr(..)
+    , ASN1DecodingReprConduit (..)
+    , ASN1DecodingConduit (..)
     , ASN1Encoding(..)
     -- * strict bytestring version
     , decodeASN1'
@@ -22,6 +25,8 @@ import qualified Data.ByteString.Lazy as L
 import Data.ASN1.Stream
 import Data.ASN1.Types
 import Data.ASN1.Error
+import Control.Monad.Catch
+import Data.Conduit
 
 -- | Describe an ASN1 decoding, that transform a bytestream into an asn1stream
 class ASN1Decoding a where
@@ -37,6 +42,12 @@ class ASN1DecodingRepr a where
 class ASN1Encoding a where
     -- | encode a stream into a lazy bytestring
     encodeASN1 :: a -> [ASN1] -> L.ByteString
+
+class ASN1DecodingReprConduit a where
+  decodeASN1ReprConduit :: forall m . MonadThrow m => a -> Conduit B.ByteString m ASN1Repr
+
+class ASN1DecodingConduit a where
+  decodeASN1Conduit :: forall m . MonadThrow m => a -> Conduit B.ByteString m ASN1
 
 -- | decode a strict bytestring into an ASN1 stream
 decodeASN1' :: ASN1Decoding a => a -> B.ByteString -> Either ASN1Error [ASN1]

--- a/encoding/asn1-encoding.cabal
+++ b/encoding/asn1-encoding.cabal
@@ -29,6 +29,9 @@ Library
                      Data.ASN1.Get
   Build-Depends:     base >= 3 && < 5
                    , bytestring
+                   , conduit
+                   , exceptions
+                   , mtl
                    , hourglass >= 0.2.6
                    , asn1-types >= 0.3.0 && < 0.4
   ghc-options:       -Wall -fwarn-tabs
@@ -40,6 +43,8 @@ Test-Suite tests-asn1-encoding
   Main-Is:           Tests.hs
   Build-depends:     base >= 3 && < 7
                    , bytestring
+                   , conduit
+                   , exceptions
                    , text
                    , mtl
                    , tasty


### PR DESCRIPTION
It's not always the case that whole bytestring that has to be decoded to ASN.1 is available. Sometimes it comes in chunks like when reading from network socket.

Conduits are useful abstraction to help in this case. They allow to preserve decoder state between pushing individual bytestring chunks and eventually convert stream of chunks to stream of ASN1 values.

My pull request adds conduit interface to ASN1 decoder. It's somewhat controversial because it introduces a bunch of additional dependencies for the whole asn1-encoding library, but still please consider it for merging.
