### PR TITLE
Fix + Test for #17

### DIFF
--- a/encoding/asn1-encoding.cabal
+++ b/encoding/asn1-encoding.cabal
@@ -44,6 +44,7 @@ Test-Suite tests-asn1-encoding
                    , mtl
                    , tasty
                    , tasty-quickcheck
+                   , tasty-hunit
                    , asn1-types
                    , asn1-encoding
                    , hourglass


### PR DESCRIPTION
I think the change you just made fixes the problem, but this is still an improvement. Specifically checking for lengths long enough to overflow makes the constraint clearer and gives a better error message. And tests are always good :)

As to your question of why `ensure` doesn't actually ensure the input is long enough: it's because the overflow makes the argument negative in this case. `B.length s0 >= n` is always true when `n` is negative, so it always acts as if there is enough input.
