### PR TITLE
Improve memory efficiency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.stack-work

--- a/data/Data/ASN1/BinaryEncoding/Parse.hs
+++ b/data/Data/ASN1/BinaryEncoding/Parse.hs
@@ -27,6 +27,8 @@ import qualified Data.ByteString.Lazy as L
 import Data.ASN1.Types
 import Data.ASN1.Get
 import Data.ASN1.Serialize
+import qualified Data.DList as DList
+import Data.DList (DList)
 import Data.Word
 import Data.Maybe (fromJust)
 
@@ -56,7 +58,7 @@ asn1LengthToConst (LenLong _ n) = Just $ fromIntegral n
 asn1LengthToConst LenIndefinite = Nothing
 
 -- | Represent the events and state thus far.
-type ParseCursor = ([ASN1Event], ParseState)
+type ParseCursor = (DList ASN1Event, ParseState)
 
 -- | run incrementally the ASN1 parser on a bytestring.
 -- the result can be either an error, or on success a list
@@ -67,17 +69,17 @@ runParseState :: ParseState -- ^ parser state
 runParseState = loop
      where
            loop iniState bs
-                | B.null bs = terminateAugment (([], iniState), bs) >>= (Right . fst)
+                | B.null bs = terminateAugment ((DList.empty, iniState), bs) >>= (Right . fst)
                 | otherwise = go iniState bs >>= terminateAugment
                                              >>= \((evs, newState), nbs) -> loop newState nbs
-                                             >>= (Right . first (evs ++))
+                                             >>= (Right . first (DList.append evs))
 
            terminateAugment ret@((evs, ParseState stackEnd pe pos), r) =
                 case stackEnd of
                     Just endPos:xs
                          | pos > endPos  -> Left StreamConstructionWrongSize
-                         | pos == endPos -> terminateAugment ((evs ++ [ConstructionEnd], ParseState xs pe pos), r)
-                         | otherwise     -> Right ret 
+                         | pos == endPos -> terminateAugment ((DList.snoc evs ConstructionEnd, ParseState xs pe pos), r)
+                         | otherwise     -> Right ret
                     _                    -> Right ret
 
            -- go get one element (either a primitive or a header) from the bytes
@@ -86,35 +88,35 @@ runParseState = loop
            go (ParseState stackEnd (ExpectHeader cont) pos) bs =
                 case runGetHeader cont pos bs of
                      Fail s                 -> Left $ ParsingHeaderFail s
-                     Partial f              -> Right (([], ParseState stackEnd (ExpectHeader $ Just f) pos), B.empty)
+                     Partial f              -> Right ((DList.empty, ParseState stackEnd (ExpectHeader $ Just f) pos), B.empty)
                      Done hdr nPos remBytes
                         | isEOC hdr -> case stackEnd of
                                            []                  -> Left StreamUnexpectedEOC
                                            Just _:_            -> Left StreamUnexpectedEOC
-                                           Nothing:newStackEnd -> Right ( ( [ConstructionEnd]
+                                           Nothing:newStackEnd -> Right ( ( DList.singleton ConstructionEnd
                                                                           , ParseState newStackEnd (ExpectHeader Nothing) nPos)
                                                                         , remBytes)
                         | otherwise -> case hdr of
                                        (ASN1Header _ _ True len)  ->
                                            let nEnd = (nPos +) `fmap` asn1LengthToConst len
-                                           in Right ( ( [Header hdr,ConstructionBegin]
+                                           in Right ( ( DList.fromList [Header hdr,ConstructionBegin]
                                                       , ParseState (nEnd:stackEnd) (ExpectHeader Nothing) nPos)
                                                     , remBytes)
                                        (ASN1Header _ _ False LenIndefinite) -> Left StreamInfinitePrimitive
                                        (ASN1Header _ _ False len) ->
                                            let pLength = fromJust $ asn1LengthToConst len
                                            in if pLength == 0
-                                                 then Right ( ( [Header hdr,Primitive B.empty]
+                                                 then Right ( ( DList.fromList [Header hdr,Primitive B.empty]
                                                               , ParseState stackEnd (ExpectHeader Nothing) nPos)
                                                             , remBytes)
-                                                 else Right ( ( [Header hdr]
+                                                 else Right ( ( DList.singleton (Header hdr)
                                                               , ParseState stackEnd (ExpectPrimitive pLength Nothing) nPos)
                                                             , remBytes)
            go (ParseState stackEnd (ExpectPrimitive len cont) pos) bs =
                 case runGetPrimitive cont len pos bs of
                      Fail _               -> error "primitive parsing failed"
-                     Partial f            -> Right (([], ParseState stackEnd (ExpectPrimitive len $ Just f) pos), B.empty)
-                     Done p nPos remBytes -> Right (([Primitive p], ParseState stackEnd (ExpectHeader Nothing) nPos), remBytes)
+                     Partial f            -> Right ((DList.empty, ParseState stackEnd (ExpectPrimitive len $ Just f) pos), B.empty)
+                     Done p nPos remBytes -> Right ((DList.singleton (Primitive p), ParseState stackEnd (ExpectHeader Nothing) nPos), remBytes)
 
            runGetHeader Nothing  = \pos -> runGetPos pos getHeader
            runGetHeader (Just f) = const f
@@ -130,14 +132,16 @@ isParseDone _                                        = False
 
 -- | Parse one lazy bytestring and returns on success all ASN1 events associated.
 parseLBS :: L.ByteString -> Either ASN1Error [ASN1Event]
-parseLBS lbs = foldrEither process ([], newParseState) (L.toChunks lbs) >>= onSuccess
-    where 
+parseLBS lbs = foldrEither process (DList.empty, newParseState) (L.toChunks lbs) >>= onSuccess
+    where
+          onSuccess :: (DList ASN1Event, ParseState) -> Either ASN1Error [ASN1Event]
           onSuccess (allEvs, finalState)
-                  | isParseDone finalState = Right $ concat $ reverse allEvs
+                  | isParseDone finalState = Right $ DList.toList $ allEvs
                   | otherwise              = Left ParsingPartial
 
-          process :: ([[ASN1Event]], ParseState) -> ByteString -> Either ASN1Error ([[ASN1Event]], ParseState)
-          process (pevs, cState) bs = runParseState cState bs >>= \(es, cState') -> Right (es : pevs, cState')
+          process :: (DList ASN1Event, ParseState) -> ByteString -> Either ASN1Error (DList ASN1Event, ParseState)
+          process (pevs, cState) bs = runParseState cState bs >>= \(es, cState') ->
+            let res = DList.append pevs es in res `seq` Right (res, cState')
 
           foldrEither :: (a -> ByteString -> Either ASN1Error a) -> a -> [ByteString] -> Either ASN1Error a
           foldrEither _ acc []     = Right acc
@@ -147,5 +151,5 @@ parseLBS lbs = foldrEither process ([], newParseState) (L.toChunks lbs) >>= onSu
 parseBS :: ByteString -> Either ASN1Error [ASN1Event]
 parseBS bs = runParseState newParseState bs >>= onSuccess
     where onSuccess (evs, pstate)
-                    | isParseDone pstate = Right evs
+                    | isParseDone pstate = Right (DList.toList evs)
                     | otherwise          = Left ParsingPartial

--- a/data/Data/ASN1/BinaryEncoding/Parse.hs
+++ b/data/Data/ASN1/BinaryEncoding/Parse.hs
@@ -55,11 +55,6 @@ asn1LengthToConst (LenShort n)  = Just $ fromIntegral n
 asn1LengthToConst (LenLong _ n) = Just $ fromIntegral n
 asn1LengthToConst LenIndefinite = Nothing
 
--- in the future, drop this for the `mplus` with Either.
-mplusEither :: Either b a -> (a -> Either b c) -> Either b c
-mplusEither (Left e) _  = Left e
-mplusEither (Right e) f = f e
-
 -- | Represent the events and state thus far.
 type ParseCursor = ([ASN1Event], ParseState)
 
@@ -72,10 +67,10 @@ runParseState :: ParseState -- ^ parser state
 runParseState = loop
      where
            loop iniState bs
-                | B.null bs = terminateAugment (([], iniState), bs) `mplusEither` (Right . fst)
-                | otherwise = go iniState bs `mplusEither` terminateAugment
-                                             `mplusEither` \((evs, newState), nbs) -> loop newState nbs
-                                             `mplusEither` (Right . first (evs ++))
+                | B.null bs = terminateAugment (([], iniState), bs) >>= (Right . fst)
+                | otherwise = go iniState bs >>= terminateAugment
+                                             >>= \((evs, newState), nbs) -> loop newState nbs
+                                             >>= (Right . first (evs ++))
 
            terminateAugment ret@((evs, ParseState stackEnd pe pos), r) =
                 case stackEnd of
@@ -135,22 +130,22 @@ isParseDone _                                        = False
 
 -- | Parse one lazy bytestring and returns on success all ASN1 events associated.
 parseLBS :: L.ByteString -> Either ASN1Error [ASN1Event]
-parseLBS lbs = foldrEither process ([], newParseState) (L.toChunks lbs) `mplusEither` onSuccess
+parseLBS lbs = foldrEither process ([], newParseState) (L.toChunks lbs) >>= onSuccess
     where 
           onSuccess (allEvs, finalState)
                   | isParseDone finalState = Right $ concat $ reverse allEvs
                   | otherwise              = Left ParsingPartial
 
           process :: ([[ASN1Event]], ParseState) -> ByteString -> Either ASN1Error ([[ASN1Event]], ParseState)
-          process (pevs, cState) bs = runParseState cState bs `mplusEither` \(es, cState') -> Right (es : pevs, cState')
+          process (pevs, cState) bs = runParseState cState bs >>= \(es, cState') -> Right (es : pevs, cState')
 
           foldrEither :: (a -> ByteString -> Either ASN1Error a) -> a -> [ByteString] -> Either ASN1Error a
           foldrEither _ acc []     = Right acc
-          foldrEither f acc (x:xs) = f acc x `mplusEither` \nacc -> foldrEither f nacc xs
+          foldrEither f acc (x:xs) = f acc x >>= \nacc -> foldrEither f nacc xs
 
 -- | Parse one strict bytestring and returns on success all ASN1 events associated.
 parseBS :: ByteString -> Either ASN1Error [ASN1Event]
-parseBS bs = runParseState newParseState bs `mplusEither` onSuccess
+parseBS bs = runParseState newParseState bs >>= onSuccess
     where onSuccess (evs, pstate)
                     | isParseDone pstate = Right evs
                     | otherwise          = Left ParsingPartial

--- a/data/Data/ASN1/Get.hs
+++ b/data/Data/ASN1/Get.hs
@@ -98,12 +98,15 @@ instance Alternative Get where
 -- Definition directly from Control.Monad.State.Strict
 instance Monad Get where
     return a = Get $ \ s0 b0 m0 p0 _ ks -> ks s0 b0 m0 p0 a
+    {-# INLINE return #-}
 
     m >>= g  = Get $ \s0 b0 m0 p0 kf ks ->
         let ks' s1 b1 m1 p1 a = unGet (g a) s1 b1 m1 p1 kf ks
          in unGet m s0 b0 m0 p0 kf ks'
+    {-# INLINE (>>=) #-}
 
     fail     = failDesc
+    {-# INLINE fail #-}
 
 instance MonadPlus Get where
     mzero     = failDesc "mzero"

--- a/data/Data/ASN1/Internal.hs
+++ b/data/Data/ASN1/Internal.hs
@@ -20,7 +20,7 @@ import qualified Data.ByteString as B
 
 {- | uintOfBytes returns the number of bytes and the unsigned integer represented by the bytes -}
 uintOfBytes :: ByteString -> (Int, Integer)
-uintOfBytes b = (B.length b, B.foldl (\acc n -> (acc `shiftL` 8) + fromIntegral n) 0 b)
+uintOfBytes b = (B.length b, B.foldl' (\acc n -> (acc `shiftL` 8) + fromIntegral n) 0 b)
 
 --bytesOfUInt i = B.unfoldr (\x -> if x == 0 then Nothing else Just (fromIntegral (x .&. 0xff), x `shiftR` 8)) i
 bytesOfUInt :: Integer -> [Word8]

--- a/data/Data/ASN1/Prim.hs
+++ b/data/Data/ASN1/Prim.hs
@@ -62,7 +62,7 @@ import Data.ASN1.Serialize
 import Data.Serialize.Put (runPut)
 import Data.Bits
 import Data.Word
-import Data.List (unfoldr)
+import Data.List (foldl', unfoldr)
 import Data.ByteString (ByteString)
 import Data.Char (ord)
 import qualified Data.ByteString as B
@@ -320,7 +320,7 @@ getOID s = Right $ OID $ (fromIntegral (x `div` 40) : fromIntegral (x `mod` 40) 
         (x:xs) = B.unpack s
 
         groupOID :: [Word8] -> [Integer]
-        groupOID = map (foldl (\acc n -> (acc `shiftL` 7) + fromIntegral n) 0) . groupSubOID
+        groupOID = map (foldl' (\acc n -> (acc `shiftL` 7) + fromIntegral n) 0) . groupSubOID
 
         groupSubOIDHelper [] = Nothing
         groupSubOIDHelper l  = Just $ spanSubOIDbound l

--- a/data/Data/ASN1/Serialize.hs
+++ b/data/Data/ASN1/Serialize.hs
@@ -67,7 +67,7 @@ getLength = do
             return (LenShort l1)
     where
         {- uintbs return the unsigned int represented by the bytes -}
-        uintbs = B.foldl (\acc n -> (acc `shiftL` 8) + fromIntegral n) 0
+        uintbs = B.foldl' (\acc n -> (acc `shiftL` 8) + fromIntegral n) 0
 
 -- | putIdentifier encode an ASN1 Identifier into a marshalled value
 putHeader :: ASN1Header -> Put

--- a/data/Data/ASN1/Stream.hs
+++ b/data/Data/ASN1/Stream.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 -- |
 -- Module      : Data.ASN1.Stream
 -- License     : BSD-style
@@ -27,13 +28,13 @@ data ASN1ConstructionType = Sequence
                           deriving (Show,Eq)
 
 -- | Define high level ASN1 object.
-data ASN1 = Boolean Bool
-          | IntVal Integer
+data ASN1 = Boolean {-# UNPACK #-} !Bool
+          | IntVal {-# UNPACK #-} !Integer
           | BitString BitArray
           | OctetString L.ByteString
           | Null
           | OID [Integer]
-          | Real Double
+          | Real {-# UNPACK #-} !Double
           | Enumerated
           | UTF8String String
           | NumericString L.ByteString
@@ -61,11 +62,17 @@ type ASN1Repr = (ASN1, [ASN1Event])
 
 getConstructedEnd :: Int -> [ASN1] -> ([ASN1],[ASN1])
 getConstructedEnd _ xs@[]                = (xs, [])
-getConstructedEnd i ((x@(Start _)):xs)   = let (yz, zs) = getConstructedEnd (i+1) xs in (x:yz,zs)
-getConstructedEnd i ((x@(End _)):xs)
+getConstructedEnd !i ((x@(Start _)):xs)   = let (yz, zs) = getConstructedEnd (i+1) xs
+                                                acc      = x:yz
+                                                in acc `seq` (acc,zs)
+getConstructedEnd !i ((x@(End _)):xs)
     | i == 0    = ([], xs)
-    | otherwise = let (ys, zs) = getConstructedEnd (i-1) xs in (x:ys,zs)
-getConstructedEnd i (x:xs)               = let (ys, zs) = getConstructedEnd i xs in (x:ys,zs)
+    | otherwise = let (ys, zs) = getConstructedEnd (i-1) xs
+                      acc      = x:ys
+                      in acc `seq` (acc,zs)
+getConstructedEnd !i (x:xs)               = let (ys, zs) = getConstructedEnd i xs
+                                                acc      = x:ys
+                                                in acc `seq` (acc,zs)
 
 getConstructedEndRepr :: [ASN1Repr] -> ([ASN1Repr],[ASN1Repr])
 getConstructedEndRepr = g
@@ -76,6 +83,12 @@ getConstructedEndRepr = g
           getEnd :: Int -> [ASN1Repr] -> ([ASN1Repr],[ASN1Repr])
           getEnd _ []                    = ([], [])
           getEnd 0 xs                    = ([], xs)
-          getEnd i ((x@(Start _, _)):xs) = let (ys, zs) = getEnd (i+1) xs in (x:ys,zs)
-          getEnd i ((x@(End _, _)):xs)   = let (ys, zs) = getEnd (i-1) xs in (x:ys,zs)
-          getEnd i (x:xs)                = let (ys, zs) = getEnd i xs in (x:ys,zs)
+          getEnd !i ((x@(Start _, _)):xs) = let (ys, zs) = getEnd (i+1) xs
+                                                acc      = x:ys
+                                                in acc `seq` (acc,zs)
+          getEnd !i ((x@(End _, _)):xs)   = let (ys, zs) = getEnd (i-1) xs
+                                                acc      = x:ys
+                                                in acc `seq` (acc,zs)
+          getEnd !i (x:xs)                = let (ys, zs) = getEnd i xs
+                                                acc      = x:ys
+                                                in acc `seq` (acc,zs)

--- a/data/Data/ASN1/Types.hs
+++ b/data/Data/ASN1/Types.hs
@@ -35,13 +35,13 @@ data ASN1Class = Universal
 type ASN1Tag = Int
 
 -- | ASN1 Length with all different formats
-data ASN1Length = LenShort Int      -- ^ Short form with only one byte. length has to be < 127.
-                | LenLong Int Int   -- ^ Long form of N bytes
+data ASN1Length = LenShort {-# UNPACK #-} !Int      -- ^ Short form with only one byte. length has to be < 127.
+                | LenLong {-# UNPACK #-} !Int {-# UNPACK #-} !Int   -- ^ Long form of N bytes
                 | LenIndefinite     -- ^ Length is indefinite expect an EOC in the stream to finish the type
                 deriving (Show,Eq)
 
 -- | ASN1 Header with the class, tag, constructed flag and length.
-data ASN1Header = ASN1Header !ASN1Class !ASN1Tag !Bool !ASN1Length
+data ASN1Header = ASN1Header !ASN1Class !ASN1Tag {-# UNPACK #-} !Bool !ASN1Length
     deriving (Show,Eq)
 
 -- | represent one event from an asn1 data stream

--- a/data/asn1-data.cabal
+++ b/data/asn1-data.cabal
@@ -26,6 +26,7 @@ Library
                    , text >= 0.11
                    , mtl
                    , cereal
+                   , dlist
 
   Exposed-modules:   Data.ASN1.BitArray
                      Data.ASN1.Types

--- a/encoding/Data/ASN1/BinaryEncoding/Parse.hs
+++ b/encoding/Data/ASN1/BinaryEncoding/Parse.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 -- |
 -- Module      : Data.ASN1.BinaryEncoding.Parse
 -- License     : BSD-style
@@ -81,7 +82,7 @@ runParseState = loop
                                              >>= \((evs, newState), nbs) -> loop newState nbs
                                              >>= (Right . first (DList.append evs))
 
-           terminateAugment ret@((evs, ParseState stackEnd pe pos), r) =
+           terminateAugment ret@((!evs, ParseState stackEnd pe pos), r) =
                 case stackEnd of
                     Just endPos:xs
                          | pos > endPos  -> Left StreamConstructionWrongSize

--- a/encoding/Data/ASN1/BinaryEncoding/Parse.hs
+++ b/encoding/Data/ASN1/BinaryEncoding/Parse.hs
@@ -31,6 +31,8 @@ import Data.ASN1.Get
 import Data.ASN1.Serialize
 import Data.Word
 import Data.Maybe (fromJust)
+import qualified Data.DList as DList
+import Data.DList (DList)
 
 -- | nothing means the parser stop this construction on
 -- an ASN1 end tag, otherwise specify the position
@@ -63,7 +65,7 @@ asn1LengthToConst (LenLong _ n) = Just $ fromIntegral n
 asn1LengthToConst LenIndefinite = Nothing
 
 -- | Represent the events and state thus far.
-type ParseCursor = ([ASN1Event], ParseState)
+type ParseCursor = (DList ASN1Event, ParseState)
 
 -- | run incrementally the ASN1 parser on a bytestring.
 -- the result can be either an error, or on success a list
@@ -74,17 +76,17 @@ runParseState :: ParseState -- ^ parser state
 runParseState = loop
      where
            loop iniState bs
-                | B.null bs = terminateAugment (([], iniState), bs) >>= (Right . fst)
+                | B.null bs = terminateAugment ((DList.empty, iniState), bs) >>= (Right . fst)
                 | otherwise = go iniState bs >>= terminateAugment
                                              >>= \((evs, newState), nbs) -> loop newState nbs
-                                             >>= (Right . first (evs ++))
+                                             >>= (Right . first (DList.append evs))
 
            terminateAugment ret@((evs, ParseState stackEnd pe pos), r) =
                 case stackEnd of
                     Just endPos:xs
                          | pos > endPos  -> Left StreamConstructionWrongSize
-                         | pos == endPos -> terminateAugment ((evs ++ [ConstructionEnd], ParseState xs pe pos), r)
-                         | otherwise     -> Right ret 
+                         | pos == endPos -> terminateAugment ((DList.snoc evs ConstructionEnd, ParseState xs pe pos), r)
+                         | otherwise     -> Right ret
                     _                    -> Right ret
 
            -- go get one element (either a primitive or a header) from the bytes
@@ -93,35 +95,35 @@ runParseState = loop
            go (ParseState stackEnd (ExpectHeader cont) pos) bs =
                 case runGetHeader cont pos bs of
                      Fail s                 -> Left $ ParsingHeaderFail s
-                     Partial f              -> Right (([], ParseState stackEnd (ExpectHeader $ Just f) pos), B.empty)
+                     Partial f              -> Right ((DList.empty, ParseState stackEnd (ExpectHeader $ Just f) pos), B.empty)
                      Done hdr nPos remBytes
                         | isEOC hdr -> case stackEnd of
-                                           []                  -> Right (([], ParseState [] (ExpectHeader Nothing) nPos), remBytes)
+                                           []                  -> Right ((DList.empty, ParseState [] (ExpectHeader Nothing) nPos), remBytes)
                                            Just _:_            -> Left StreamUnexpectedEOC
-                                           Nothing:newStackEnd -> Right ( ( [ConstructionEnd]
+                                           Nothing:newStackEnd -> Right ( ( DList.singleton ConstructionEnd
                                                                           , ParseState newStackEnd (ExpectHeader Nothing) nPos)
                                                                         , remBytes)
                         | otherwise -> case hdr of
                                        (ASN1Header _ _ True len)  ->
                                            let nEnd = (nPos +) `fmap` asn1LengthToConst len
-                                           in Right ( ( [Header hdr,ConstructionBegin]
+                                           in Right ( ( DList.fromList [Header hdr,ConstructionBegin]
                                                       , ParseState (nEnd:stackEnd) (ExpectHeader Nothing) nPos)
                                                     , remBytes)
                                        (ASN1Header _ _ False LenIndefinite) -> Left StreamInfinitePrimitive
                                        (ASN1Header _ _ False len) ->
                                            let pLength = fromJust $ asn1LengthToConst len
                                            in if pLength == 0
-                                                 then Right ( ( [Header hdr,Primitive B.empty]
+                                                 then Right ( ( DList.fromList [Header hdr,Primitive B.empty]
                                                               , ParseState stackEnd (ExpectHeader Nothing) nPos)
                                                             , remBytes)
-                                                 else Right ( ( [Header hdr]
+                                                 else Right ( ( DList.singleton (Header hdr)
                                                               , ParseState stackEnd (ExpectPrimitive pLength Nothing) nPos)
                                                             , remBytes)
            go (ParseState stackEnd (ExpectPrimitive len cont) pos) bs =
                 case runGetPrimitive cont len pos bs of
                      Fail _               -> error "primitive parsing failed"
-                     Partial f            -> Right (([], ParseState stackEnd (ExpectPrimitive len $ Just f) pos), B.empty)
-                     Done p nPos remBytes -> Right (([Primitive p], ParseState stackEnd (ExpectHeader Nothing) nPos), remBytes)
+                     Partial f            -> Right ((DList.empty, ParseState stackEnd (ExpectPrimitive len $ Just f) pos), B.empty)
+                     Done p nPos remBytes -> Right ((DList.singleton (Primitive p), ParseState stackEnd (ExpectHeader Nothing) nPos), remBytes)
 
            runGetHeader Nothing  = \pos -> runGetPos pos getHeader
            runGetHeader (Just f) = const f
@@ -137,14 +139,16 @@ isParseDone _                                        = False
 
 -- | Parse one lazy bytestring and returns on success all ASN1 events associated.
 parseLBS :: L.ByteString -> Either ASN1Error [ASN1Event]
-parseLBS lbs = foldrEither process ([], newParseState) (L.toChunks lbs) >>= onSuccess
-    where 
+parseLBS lbs = foldrEither process (DList.empty, newParseState) (L.toChunks lbs) >>= onSuccess
+    where
+          onSuccess :: (DList ASN1Event, ParseState) -> Either ASN1Error [ASN1Event]
           onSuccess (allEvs, finalState)
-                  | isParseDone finalState = Right $ concat $ reverse allEvs
+                  | isParseDone finalState = Right $ DList.toList $ allEvs
                   | otherwise              = Left ParsingPartial
 
-          process :: ([[ASN1Event]], ParseState) -> ByteString -> Either ASN1Error ([[ASN1Event]], ParseState)
-          process (pevs, cState) bs = runParseState cState bs >>= \(es, cState') -> Right (es : pevs, cState')
+          process :: (DList ASN1Event, ParseState) -> ByteString -> Either ASN1Error (DList ASN1Event, ParseState)
+          process (pevs, cState) bs = runParseState cState bs >>= \(es, cState') ->
+            let res = DList.append pevs es in res `seq` Right (res, cState')
 
           foldrEither :: (a -> ByteString -> Either ASN1Error a) -> a -> [ByteString] -> Either ASN1Error a
           foldrEither _ acc []     = Right acc
@@ -154,5 +158,5 @@ parseLBS lbs = foldrEither process ([], newParseState) (L.toChunks lbs) >>= onSu
 parseBS :: ByteString -> Either ASN1Error [ASN1Event]
 parseBS bs = runParseState newParseState bs >>= onSuccess
     where onSuccess (evs, pstate)
-                    | isParseDone pstate = Right evs
+                    | isParseDone pstate = Right (DList.toList evs)
                     | otherwise          = Left ParsingPartial

--- a/encoding/Data/ASN1/Get.hs
+++ b/encoding/Data/ASN1/Get.hs
@@ -98,12 +98,15 @@ instance Alternative Get where
 -- Definition directly from Control.Monad.State.Strict
 instance Monad Get where
     return a = Get $ \ s0 b0 m0 p0 _ ks -> ks s0 b0 m0 p0 a
+    {-# INLINE return #-}
 
     m >>= g  = Get $ \s0 b0 m0 p0 kf ks ->
         let ks' s1 b1 m1 p1 a = unGet (g a) s1 b1 m1 p1 kf ks
          in unGet m s0 b0 m0 p0 kf ks'
+    {-# INLINE (>>=) #-}
 
     fail     = failDesc
+    {-# INLINE fail #-}
 
 instance MonadPlus Get where
     mzero     = failDesc "mzero"

--- a/encoding/Data/ASN1/Internal.hs
+++ b/encoding/Data/ASN1/Internal.hs
@@ -20,7 +20,7 @@ import qualified Data.ByteString as B
 
 {- | uintOfBytes returns the number of bytes and the unsigned integer represented by the bytes -}
 uintOfBytes :: ByteString -> (Int, Integer)
-uintOfBytes b = (B.length b, B.foldl (\acc n -> (acc `shiftL` 8) + fromIntegral n) 0 b)
+uintOfBytes b = (B.length b, B.foldl' (\acc n -> (acc `shiftL` 8) + fromIntegral n) 0 b)
 
 --bytesOfUInt i = B.unfoldr (\x -> if x == 0 then Nothing else Just (fromIntegral (x .&. 0xff), x `shiftR` 8)) i
 bytesOfUInt :: Integer -> [Word8]

--- a/encoding/Data/ASN1/Prim.hs
+++ b/encoding/Data/ASN1/Prim.hs
@@ -50,7 +50,7 @@ import Data.ASN1.Error
 import Data.ASN1.Serialize
 import Data.Bits
 import Data.Word
-import Data.List (unfoldr)
+import Data.List (foldl', unfoldr)
 import Data.ByteString (ByteString)
 import Data.Char (ord, isDigit)
 import qualified Data.ByteString as B
@@ -246,7 +246,7 @@ getOID s = Right $ OID $ (fromIntegral (x `div` 40) : fromIntegral (x `mod` 40) 
         (x:xs) = B.unpack s
 
         groupOID :: [Word8] -> [Integer]
-        groupOID = map (foldl (\acc n -> (acc `shiftL` 7) + fromIntegral n) 0) . groupSubOID
+        groupOID = map (foldl' (\acc n -> (acc `shiftL` 7) + fromIntegral n) 0) . groupSubOID
 
         groupSubOIDHelper [] = Nothing
         groupSubOIDHelper l  = Just $ spanSubOIDbound l
@@ -322,7 +322,7 @@ getTime timeType bs
                                                 else ([], z)
 
         toInt :: String -> Int
-        toInt = foldl (\acc w -> acc * 10 + (ord w - ord '0')) 0
+        toInt = foldl' (\acc w -> acc * 10 + (ord w - ord '0')) 0
 
         decodingError reason = Left $ TypeDecodingFailed ("time format invalid for " ++ show timeType ++ " : " ++ reason)
         hasNonASCII = maybe False (const True) . B.find (\c -> c > 0x7f)

--- a/encoding/Data/ASN1/Serialize.hs
+++ b/encoding/Data/ASN1/Serialize.hs
@@ -65,7 +65,7 @@ getLength = do
             return (LenShort l1)
   where
         {- uintbs return the unsigned int represented by the bytes -}
-        uintbs = B.foldl (\acc n -> (acc `shiftL` 8) + fromIntegral n) 0
+        uintbs = B.foldl' (\acc n -> (acc `shiftL` 8) + fromIntegral n) 0
 
 -- | putIdentifier encode an ASN1 Identifier into a marshalled value
 putHeader :: ASN1Header -> B.ByteString

--- a/encoding/Data/ASN1/Stream.hs
+++ b/encoding/Data/ASN1/Stream.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 -- |
 -- Module      : Data.ASN1.Stream
 -- License     : BSD-style
@@ -21,11 +22,18 @@ type ASN1Repr = (ASN1, [ASN1Event])
 
 getConstructedEnd :: Int -> [ASN1] -> ([ASN1],[ASN1])
 getConstructedEnd _ xs@[]                = (xs, [])
-getConstructedEnd i ((x@(Start _)):xs)   = let (yz, zs) = getConstructedEnd (i+1) xs in (x:yz,zs)
-getConstructedEnd i ((x@(End _)):xs)
+getConstructedEnd !i ((x@(Start _)):xs)   = let (yz, zs) = getConstructedEnd (i+1) xs
+                                                acc      = x:yz
+                                                in acc `seq` (acc,zs)
+getConstructedEnd !i ((x@(End _)):xs)
     | i == 0    = ([], xs)
-    | otherwise = let (ys, zs) = getConstructedEnd (i-1) xs in (x:ys,zs)
-getConstructedEnd i (x:xs)               = let (ys, zs) = getConstructedEnd i xs in (x:ys,zs)
+    | otherwise = let (ys, zs) = getConstructedEnd (i-1) xs
+                      acc      = x:ys
+                      in acc `seq` (acc,zs)
+getConstructedEnd !i (x:xs)               = let (ys, zs) = getConstructedEnd i xs
+                                                acc      = x:ys
+                                                in acc `seq` (acc,zs)
+
 
 getConstructedEndRepr :: [ASN1Repr] -> ([ASN1Repr],[ASN1Repr])
 getConstructedEndRepr = g
@@ -36,6 +44,12 @@ getConstructedEndRepr = g
           getEnd :: Int -> [ASN1Repr] -> ([ASN1Repr],[ASN1Repr])
           getEnd _ []                    = ([], [])
           getEnd 0 xs                    = ([], xs)
-          getEnd i ((x@(Start _, _)):xs) = let (ys, zs) = getEnd (i+1) xs in (x:ys,zs)
-          getEnd i ((x@(End _, _)):xs)   = let (ys, zs) = getEnd (i-1) xs in (x:ys,zs)
-          getEnd i (x:xs)                = let (ys, zs) = getEnd i xs in (x:ys,zs)
+          getEnd !i ((x@(Start _, _)):xs) = let (ys, zs) = getEnd (i+1) xs
+                                                acc      = x:ys
+                                                in acc `seq` (acc,zs)
+          getEnd !i ((x@(End _, _)):xs)   = let (ys, zs) = getEnd (i-1) xs
+                                                acc      = x:ys
+                                                in acc `seq` (acc,zs)
+          getEnd !i (x:xs)                = let (ys, zs) = getEnd i xs
+                                                acc      = x:ys
+                                                in acc `seq` (acc,zs)

--- a/encoding/asn1-encoding.cabal
+++ b/encoding/asn1-encoding.cabal
@@ -29,6 +29,7 @@ Library
                      Data.ASN1.Get
   Build-Depends:     base >= 3 && < 5
                    , bytestring
+                   , dlist
                    , hourglass >= 0.2.6
                    , asn1-types >= 0.3.0 && < 0.4
   ghc-options:       -Wall -fwarn-tabs
@@ -40,6 +41,7 @@ Test-Suite tests-asn1-encoding
   Main-Is:           Tests.hs
   Build-depends:     base >= 3 && < 7
                    , bytestring
+                   , dlist
                    , text
                    , mtl
                    , tasty

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-6.13
+packages:
+  - types
+  - data
+  - encoding
+  - parse

--- a/types/Data/ASN1/Types.hs
+++ b/types/Data/ASN1/Types.hs
@@ -40,17 +40,17 @@ data ASN1TimeType = TimeUTC         -- ^ ASN1 UTCTime Type: limited between 1950
 
 -- | Define high level ASN1 object.
 data ASN1 =
-      Boolean Bool
-    | IntVal  Integer
-    | BitString BitArray
-    | OctetString ByteString
+      Boolean {-# UNPACK #-} !Bool
+    | IntVal  {-# UNPACK #-} !Integer
+    | BitString !BitArray
+    | OctetString !ByteString
     | Null
     | OID  OID
-    | Real Double
-    | Enumerated Integer
+    | Real {-# UNPACK #-} !Double
+    | Enumerated {-# UNPACK #-} !Integer
     | ASN1String ASN1CharacterString
     | ASN1Time ASN1TimeType DateTime (Maybe TimezoneOffset)
-    | Other ASN1Class ASN1Tag ByteString
+    | Other ASN1Class ASN1Tag !ByteString
     | Start ASN1ConstructionType
     | End   ASN1ConstructionType
     deriving (Show, Eq)

--- a/types/Data/ASN1/Types/Lowlevel.hs
+++ b/types/Data/ASN1/Types/Lowlevel.hs
@@ -30,13 +30,13 @@ data ASN1Class = Universal
 type ASN1Tag = Int
 
 -- | ASN1 Length with all different formats
-data ASN1Length = LenShort Int      -- ^ Short form with only one byte. length has to be < 127.
-                | LenLong Int Int   -- ^ Long form of N bytes
+data ASN1Length = LenShort {-# UNPACK #-} !Int      -- ^ Short form with only one byte. length has to be < 127.
+                | LenLong {-# UNPACK #-} !Int {-# UNPACK #-} !Int   -- ^ Long form of N bytes
                 | LenIndefinite     -- ^ Length is indefinite expect an EOC in the stream to finish the type
                 deriving (Show,Eq)
 
 -- | ASN1 Header with the class, tag, constructed flag and length.
-data ASN1Header = ASN1Header !ASN1Class !ASN1Tag !Bool !ASN1Length
+data ASN1Header = ASN1Header !ASN1Class !ASN1Tag {-# UNPACK #-} !Bool !ASN1Length
     deriving (Show,Eq)
 
 -- | represent one event from an asn1 data stream

--- a/types/Data/ASN1/Types/String.hs
+++ b/types/Data/ASN1/Types/String.hs
@@ -19,6 +19,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 import Data.Bits
+import Data.List (foldl')
 import Data.Word
 
 -- a note on T61 encodings. The actual specification of a T61 character set seems
@@ -105,7 +106,7 @@ decodeUTF8 b = loop 0 $ B.unpack b
         uncont _ _ _ _ = error "invalid number of bytes for continuation"
         decodeCont :: Word8 -> [Word8] -> Char
         decodeCont iniV l
-            | all isContByte l = toEnum $ foldl (\acc v -> (acc `shiftL` 6) + fromIntegral v) (fromIntegral iniV) $ map (\v -> v .&. 0x3f) l
+            | all isContByte l = toEnum $ foldl' (\acc v -> (acc `shiftL` 6) + fromIntegral v) (fromIntegral iniV) $ map (\v -> v .&. 0x3f) l
             | otherwise        = error "continuation bytes invalid"
         isContByte v = v `testBit` 7 && v `isClear` 6
         isClear v i = not (v `testBit` i)


### PR DESCRIPTION
Hey @vincenthz !

This is one of a series of PR hitting different projects (namely `hs-pem`, `hs-asn1` and `hs-certificate`) aimed at improving the memory/time efficiency of these libraries and therefore reduce the memory footprint of virtually all the Haskell servers using `tls` and `http-client-tls` (which has reverse deps toward these libs).

I started by profiling the memory allocation of my production web server, and I've noticed that most of the memory footprint was coming from `getTlsConnection`:

![screen shot 2016-08-26 at 12 09 26](https://cloud.githubusercontent.com/assets/442035/18200118/946f0d9c-7103-11e6-8632-0ee0e5e48264.png)

Digging deeper I have isolated most of the memory consumption as coming from the `MacOS` module, which could be pinned down to the `parseSigned` function (for which I will open a separate PR on `hs-certificate). But despite that, I was able to reduce memory footprint quite a bit by using very simple transformations on this project. An example of the`before/after`:

![screen shot 2016-08-30 at 11 29 09](https://cloud.githubusercontent.com/assets/442035/18200208/07ca0bac-7104-11e6-9eea-f2b4fc69a96c.png)

![screen shot 2016-08-31 at 15 02 38](https://cloud.githubusercontent.com/assets/442035/18200223/15efe10c-7104-11e6-83b5-9cffd0bb8576.png)

Memory consumption went down from roughly `168,573,032` to `141,581,480` (consistently),
and times seems to have improved as well. Considering it's quite a big patch, I will try to break it down. I have:
- Replace the inner data structure of `ParseCursor` to use a `DList`, to avoid expensive `reverse` and `++`
- Removed `mplusEither` which has exactly the same semantic of `>>=` (unless I'm missing something
- Used `foldl'` where appropriate
- Used `UNPACK` and strict fields, where appropriate
- Used `seq` and `BangPatterns` to make certain accumulators strict in recursive functions
- Inlined the definition for `return, (>>=) and fail` in the `Get` monad, as the `cereal` guys are doing these days
- Added a very simple `stack.yaml`
