### PR TITLE
asn1-parse: clarify usage of onNextContainer

### DIFF
--- a/parse/Data/ASN1/Parse.hs
+++ b/parse/Data/ASN1/Parse.hs
@@ -137,7 +137,9 @@ getNextContainer ty = do
               | otherwise     -> throwParseError "not an expected container"
 
 
--- | run a function of the next elements of a container of specified type
+-- | Run a function of the next elements of a container of specified type.
+-- The function has to handle all the ASN.1 objects of the container,
+-- similarly to when using 'runParseASN1'.
 onNextContainer :: ASN1ConstructionType -> ParseASN1 a -> ParseASN1 a
 onNextContainer ty f = getNextContainer ty >>= either throwParseError return . runParseASN1 f
 


### PR DESCRIPTION
The existing documentation of `Data.ASN1.Parse.onNextContainer` did not
make clear that the supplied function neads to handle all elements of
the container. This is due to the usage of `runParseASN1`, erroring on
non-complete consumption of state, which is only apparent when reading
the actual implementation code.

contributes to #37