### PR TITLE
Require Cabal-Version 1.8

### DIFF
--- a/types/asn1-types.cabal
+++ b/types/asn1-types.cabal
@@ -10,7 +10,7 @@ Synopsis:            ASN.1 types
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Cabal-Version:       >=1.6
+Cabal-Version:       >=1.8
 Homepage:            http://github.com/vincenthz/hs-asn1
 
 Library


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: asn1-types.cabal:17:34: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```